### PR TITLE
Se Oculta el botón "Volver" en `RegistroExitosoFragment`

### DIFF
--- a/app/src/main/java/com/deportes/clubdeportivo/RegistroActivity.kt
+++ b/app/src/main/java/com/deportes/clubdeportivo/RegistroActivity.kt
@@ -19,6 +19,7 @@ class RegistroActivity : AppCompatActivity() {
 
 
         // Obtenemos referencias a los elementos de la interfaz de usuario
+        val volverButton = findViewById<Button>(R.id.buttonVolver)
         val iniciarSesionTextView: TextView = findViewById(R.id.textViewIniciarSesion)
         val btnCrearCuenta: Button = findViewById<Button>(R.id.buttonCrearCuenta)
 
@@ -40,24 +41,37 @@ class RegistroActivity : AppCompatActivity() {
 
         // Logica del botón crear cuenta
         btnCrearCuenta.setOnClickListener {
-            val registroExitosoDialog =
-                RegistroExitosoFragment.newInstance()
+            val registroExitosoDialog = RegistroExitosoFragment.newInstance(false)
             registroExitosoDialog.setOnVolverClickListener {
                 finish()
             }
+
+            // Mostrar el diálogo de registro exitoso primero
             registroExitosoDialog.show(
                 supportFragmentManager,
                 RegistroExitosoFragment.TAG
-            ) // Usar el nuevo TAG
+            )
 
-            // Vista de carga de pantalla
-            val cargandoDialog = CargandoFragment.newInstance()
-            cargandoDialog.show(supportFragmentManager, CargandoFragment.TAG)
             Handler(Looper.getMainLooper()).postDelayed({
-                val cargandoDialog = supportFragmentManager.findFragmentByTag(CargandoFragment.TAG) as? CargandoFragment
-                cargandoDialog?.dismiss()
-                startActivity(Intent(this, MenuPrincipalActivity::class.java))
-            }, 3000)
+                // Ocultar el diálogo de registro exitoso después de 1 segundo
+                registroExitosoDialog.dismiss()
+
+
+                // Mostrar el diálogo de carga después de ocultar el registro exitoso
+                val cargandoDialog = CargandoFragment.newInstance()
+                cargandoDialog.show(
+                    supportFragmentManager,
+                    CargandoFragment.TAG
+                )
+
+                Handler(Looper.getMainLooper()).postDelayed({
+                    // Ocultar el diálogo de carga después de 3 segundos
+                    val cargandoDialog =
+                        supportFragmentManager.findFragmentByTag(CargandoFragment.TAG) as? CargandoFragment
+                    cargandoDialog?.dismiss()
+                    startActivity(Intent(this, MenuPrincipalActivity::class.java))
+                }, 3000)
+            }, 1000)
         }
     }
 }

--- a/app/src/main/java/com/deportes/clubdeportivo/RegistroExitosoFragment.kt
+++ b/app/src/main/java/com/deportes/clubdeportivo/RegistroExitosoFragment.kt
@@ -10,6 +10,21 @@ import androidx.fragment.app.DialogFragment
 class RegistroExitosoFragment : DialogFragment() {
 
     private var onVolverClickListener: (() -> Unit)? = null
+    private var volverButton: Button? = null
+    private var mostrarVolver = true // Nuevo: controla la visibilidad del botón
+
+    companion object {
+        const val TAG = "RegistroExitosoFragment"
+        private const val ARG_MOSTRAR_VOLVER = "mostrarVolver"
+
+        fun newInstance(mostrarVolver: Boolean = true): RegistroExitosoFragment { // Valor por defecto = true
+            val fragment = RegistroExitosoFragment()
+            val args = Bundle()
+            args.putBoolean(ARG_MOSTRAR_VOLVER, mostrarVolver)
+            fragment.arguments = args
+            return fragment
+        }
+    }
 
     fun setOnVolverClickListener(listener: () -> Unit) {
         onVolverClickListener = listener
@@ -20,26 +35,36 @@ class RegistroExitosoFragment : DialogFragment() {
         dialog?.window?.setBackgroundDrawableResource(android.R.color.transparent)
     }
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // Obtener el argumento al crear el fragment
+        mostrarVolver = arguments?.getBoolean(ARG_MOSTRAR_VOLVER, true) ?: true
+    }
+
     override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
+        inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        // Inflar el layout del Fragment.
         val view = inflater.inflate(R.layout.fragment_registro_exitoso, container, false)
+        volverButton = view.findViewById(R.id.buttonVolver)  // Inicializar el Button
+        return view
+    }
 
-        val volverButton = view.findViewById<Button>(R.id.buttonVolver)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // Controlar la visibilidad del botón
+        volverButton?.visibility = if (mostrarVolver) View.VISIBLE else View.GONE
+
         volverButton?.setOnClickListener {
             onVolverClickListener?.invoke()
             dismiss()
         }
-
-        return view
     }
 
-    companion object {
-        const val TAG = "FragmentRegistroExitoso"
-        fun newInstance(): RegistroExitosoFragment {
-            return RegistroExitosoFragment()
-        }
+    override fun onDestroyView() {
+        super.onDestroyView()
+        volverButton = null // Limpiar la referencia para evitar fugas de memoria
     }
 }


### PR DESCRIPTION
Se modifica `RegistroExitosoFragment` para permitir ocultar el botón "Volver". Esto se logra añadiendo un argumento booleano `mostrarVolver` al crear la instancia del fragmento.

En `RegistroActivity`:
- Al mostrar `RegistroExitosoFragment` después de un registro exitoso, se pasa `mostrarVolver = false` para ocultar el botón.
- El diálogo de "Registro Exitoso" ahora se muestra durante 1 segundo antes de mostrar el diálogo de "Cargando".